### PR TITLE
Add macOS Finder open support for Markdown files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,3 +127,4 @@ This document gives code-aware agents a concise mental model of Bedrock’s arch
 - 2026-03-21: Added a Playwright-based Electron E2E harness with test-only dialog/user-data controls for reproducible agent testing.
 - 2026-03-21: Added Sentry-ready telemetry hooks for Electron main/renderer plus Linear/GitHub helper scripts for agent issue and repo bootstrap workflows.
 - 2026-03-22: Main-process uncaught exceptions now flush telemetry and exit, and release automation no longer pushes version-bump commits directly to protected `main`.
+- 2026-03-29: Added macOS `.md` document registration plus queued Finder/open-file handling so Bedrock can appear in Finder `Open With…`, reuse the existing single window, and honor dirty-document discard prompts for externally opened Markdown files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,3 +128,4 @@ This document gives code-aware agents a concise mental model of Bedrock’s arch
 - 2026-03-21: Added Sentry-ready telemetry hooks for Electron main/renderer plus Linear/GitHub helper scripts for agent issue and repo bootstrap workflows.
 - 2026-03-22: Main-process uncaught exceptions now flush telemetry and exit, and release automation no longer pushes version-bump commits directly to protected `main`.
 - 2026-03-29: Added macOS `.md` document registration plus queued Finder/open-file handling so Bedrock can appear in Finder `Open With…`, reuse the existing single window, and honor dirty-document discard prompts for externally opened Markdown files.
+- 2026-04-19: Tightened external-open startup handling in the renderer and reset main-process renderer readiness after renderer termination so queued Finder opens recover more safely.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -84,6 +84,16 @@ const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
     icon: "./src/assets/icon",
+    extendInfo: {
+      CFBundleDocumentTypes: [
+        {
+          CFBundleTypeExtensions: ["md"],
+          CFBundleTypeName: "Markdown Document",
+          CFBundleTypeRole: "Editor",
+          LSHandlerRank: "Alternate",
+        },
+      ],
+    },
     osxSign: process.env.APPLE_IDENTITY
       ? { identity: process.env.APPLE_IDENTITY }
       : {},

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -259,19 +259,19 @@ ipcMain.handle(
         if (nextSavePath) {
           targetPath = nextSavePath;
         } else {
-        const { canceled, filePath } = await dialog.showSaveDialog(
-          BrowserWindow.fromWebContents(event.sender) ?? undefined,
-          {
-            filters: [MARKDOWN_DIALOG_FILTER],
-            defaultPath: "Untitled.md",
+          const { canceled, filePath } = await dialog.showSaveDialog(
+            BrowserWindow.fromWebContents(event.sender) ?? undefined,
+            {
+              filters: [MARKDOWN_DIALOG_FILTER],
+              defaultPath: "Untitled.md",
+            }
+          );
+
+          if (canceled || !filePath) {
+            return null;
           }
-        );
 
-        if (canceled || !filePath) {
-          return null;
-        }
-
-        targetPath = ensureMarkdownExtension(filePath);
+          targetPath = ensureMarkdownExtension(filePath);
         }
       }
 
@@ -606,6 +606,9 @@ const createWindow = (): void => {
   windowDirtyState.set(webContentsId, false);
 
   window.webContents.on("render-process-gone", (_event, details) => {
+    if (mainWindow === window) {
+      rendererReady = false;
+    }
     captureMainTelemetryMessage("Renderer process terminated", {
       reason: details.reason,
       exitCode: details.exitCode,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,6 +16,7 @@ import {
   DiscardAction,
   SaveFilePayload,
   OpenFileResult,
+  OpenSpecificFilePayload,
   SaveFileResult,
   ExportFilePayload,
 } from "../shared/types";
@@ -39,6 +40,9 @@ const ensureMarkdownExtension = (filePath: string): string => {
 const windowDirtyState = new Map<number, boolean>();
 const runtimeInfo = initializeMainTelemetry();
 const isE2EMode = runtimeInfo.e2eMode;
+const pendingExternalOpenFiles: OpenSpecificFilePayload[] = [];
+let mainWindow: BrowserWindow | null = null;
+let rendererReady = false;
 
 const testState: BedrockTestState = {
   nextOpenPath: null,
@@ -109,6 +113,55 @@ const getDiscardDescription = (action: DiscardAction): string => {
   return "close this window";
 };
 
+const isMarkdownFilePath = (filePath: string): boolean => {
+  return filePath.toLowerCase().endsWith(".md");
+};
+
+const normalizeExternalOpenPath = (
+  filePath: unknown
+): OpenSpecificFilePayload | null => {
+  if (typeof filePath !== "string" || filePath.trim() === "") {
+    return null;
+  }
+
+  const resolvedPath = path.resolve(filePath);
+  if (!isMarkdownFilePath(resolvedPath)) {
+    return null;
+  }
+
+  return { filePath: resolvedPath };
+};
+
+const deliverExternalOpenFile = (payload: OpenSpecificFilePayload): boolean => {
+  if (!mainWindow || mainWindow.isDestroyed() || !rendererReady) {
+    return false;
+  }
+
+  mainWindow.webContents.send("file:open-external", payload);
+  if (mainWindow.isMinimized()) {
+    mainWindow.restore();
+  }
+  mainWindow.focus();
+  return true;
+};
+
+const handleExternalOpenPath = (filePath: unknown): boolean => {
+  const payload = normalizeExternalOpenPath(filePath);
+  if (!payload) {
+    return false;
+  }
+
+  if (!deliverExternalOpenFile(payload)) {
+    pendingExternalOpenFiles.push(payload);
+
+    if (app.isReady() && (!mainWindow || mainWindow.isDestroyed())) {
+      createWindow();
+    }
+  }
+
+  return true;
+};
+
 const confirmDiscardChanges = async (
   browserWindow: BrowserWindow | null,
   action: DiscardAction,
@@ -169,7 +222,7 @@ ipcMain.handle(
   async (_event, filePath: string): Promise<OpenFileResult | null> => {
     try {
       // Basic security check: only allow reading .md files.
-      if (!filePath.toLowerCase().endsWith(".md")) {
+      if (!isMarkdownFilePath(filePath)) {
         console.error(
           `Rejected attempt to read non-markdown file: ${filePath}`
         );
@@ -190,6 +243,10 @@ ipcMain.handle(
     }
   }
 );
+
+ipcMain.handle("file:consume-pending-external-open", () => {
+  return pendingExternalOpenFiles.splice(0);
+});
 
 ipcMain.handle(
   "file:save",
@@ -257,6 +314,12 @@ ipcMain.on("devtools:open", (event) => {
   window?.webContents.openDevTools({ mode: "detach" });
 });
 
+ipcMain.on("app:renderer-ready", (event) => {
+  if (mainWindow && event.sender.id === mainWindow.webContents.id) {
+    rendererReady = true;
+  }
+});
+
 ipcMain.handle("app:get-version", (): string => {
   return app.getVersion();
 });
@@ -290,6 +353,10 @@ ipcMain.handle("test:get-state", () => {
 
 ipcMain.handle("test:reset-state", () => {
   return resetTestState();
+});
+
+ipcMain.handle("test:simulate-external-open", (_event, filePath: string) => {
+  return handleExternalOpenPath(filePath);
 });
 
 ipcMain.handle(
@@ -500,7 +567,7 @@ const createWindow = (): void => {
   });
 
   // Create the browser window.
-  const mainWindow = new BrowserWindow({
+  const window = new BrowserWindow({
     x: mainWindowState.x,
     y: mainWindowState.y,
     width: mainWindowState.width,
@@ -515,28 +582,30 @@ const createWindow = (): void => {
       preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
     },
   });
+  mainWindow = window;
+  rendererReady = false;
 
   // Let us register listeners on the window, so we can update the state
   // automatically (the listeners will be removed when the window is closed)
   // and restore the maximized state of the window
-  mainWindowState.manage(mainWindow);
+  mainWindowState.manage(window);
 
   if (process.platform !== "darwin") {
     // Keep shortcuts active but hide the menu bar.
-    mainWindow.setMenuBarVisibility(false);
+    window.setMenuBarVisibility(false);
   }
 
-  const webContentsId = mainWindow.webContents.id;
+  const webContentsId = window.webContents.id;
 
   // and load the index.html of the app.
-  mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+  void window.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
 
   // Open the DevTools.
   // mainWindow.webContents.openDevTools();
 
   windowDirtyState.set(webContentsId, false);
 
-  mainWindow.webContents.on("render-process-gone", (_event, details) => {
+  window.webContents.on("render-process-gone", (_event, details) => {
     captureMainTelemetryMessage("Renderer process terminated", {
       reason: details.reason,
       exitCode: details.exitCode,
@@ -544,7 +613,7 @@ const createWindow = (): void => {
     });
   });
 
-  mainWindow.webContents.on("unresponsive", () => {
+  window.webContents.on("unresponsive", () => {
     captureMainTelemetryMessage("Renderer process unresponsive", {
       webContentsId,
     });
@@ -552,7 +621,7 @@ const createWindow = (): void => {
 
   let forceClose = false;
 
-  mainWindow.on("close", async (event) => {
+  window.on("close", async (event) => {
     if (forceClose) {
       return;
     }
@@ -565,17 +634,21 @@ const createWindow = (): void => {
 
     event.preventDefault();
 
-    const confirmed = await confirmDiscardChanges(mainWindow, "close");
+    const confirmed = await confirmDiscardChanges(window, "close");
 
     if (confirmed) {
       windowDirtyState.set(webContentsId, false);
       forceClose = true;
-      mainWindow.close();
+      window.close();
     }
   });
 
-  mainWindow.on("closed", () => {
+  window.on("closed", () => {
     windowDirtyState.delete(webContentsId);
+    if (mainWindow === window) {
+      mainWindow = null;
+      rendererReady = false;
+    }
   });
 };
 
@@ -585,6 +658,28 @@ const createWindow = (): void => {
 app.on("ready", () => {
   installApplicationMenu();
   createWindow();
+
+  if (isE2EMode) {
+    try {
+      const seededPaths = JSON.parse(
+        process.env.BEDROCK_E2E_INITIAL_EXTERNAL_OPEN_PATHS ?? "[]"
+      ) as unknown;
+      if (Array.isArray(seededPaths)) {
+        seededPaths.forEach((filePath) => {
+          handleExternalOpenPath(filePath);
+        });
+      }
+    } catch (error) {
+      captureMainTelemetryException(error, {
+        operation: "parse-initial-external-open-paths",
+      });
+    }
+  }
+});
+
+app.on("open-file", (event, filePath) => {
+  event.preventDefault();
+  handleExternalOpenPath(filePath);
 });
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -6,6 +6,7 @@ import {
   SaveFilePayload,
   DiscardPromptPayload,
   OpenFileResult,
+  OpenSpecificFilePayload,
   SaveFileResult,
   ExportFilePayload,
 } from "../shared/types";
@@ -38,6 +39,23 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("file:export", payload),
   readFile: (filePath: string): Promise<OpenFileResult | null> =>
     ipcRenderer.invoke("file:read", filePath),
+  consumePendingExternalOpenFiles: (): Promise<OpenSpecificFilePayload[]> =>
+    ipcRenderer.invoke("file:consume-pending-external-open"),
+  onExternalOpenFile: (
+    callback: (payload: OpenSpecificFilePayload) => void
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: OpenSpecificFilePayload
+    ) => callback(payload);
+    ipcRenderer.on("file:open-external", listener);
+    return () => {
+      ipcRenderer.removeListener("file:open-external", listener);
+    };
+  },
+  notifyRendererReady: (): void => {
+    ipcRenderer.send("app:renderer-ready");
+  },
   test:
     process.env.BEDROCK_E2E === "1"
       ? {
@@ -47,6 +65,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
             ipcRenderer.invoke("test:get-state"),
           reset: (): Promise<BedrockTestState | null> =>
             ipcRenderer.invoke("test:reset-state"),
+          simulateExternalOpen: (filePath: string): Promise<boolean> =>
+            ipcRenderer.invoke("test:simulate-external-open", filePath),
         }
       : undefined,
 });

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -197,11 +197,13 @@ const App = () => {
 
   const enqueueExternalOpen = useCallback(
     (payload: OpenSpecificFilePayload) => {
-      externalOpenSequenceRef.current = externalOpenSequenceRef.current.then(
-        async () => {
+      externalOpenSequenceRef.current = externalOpenSequenceRef.current
+        .then(async () => {
           await handleExternalOpen(payload);
-        }
-      );
+        })
+        .catch((error) => {
+          console.error("Failed to handle external open:", error);
+        });
     },
     [handleExternalOpen]
   );
@@ -211,30 +213,38 @@ const App = () => {
     setSettings(loaded);
 
     const initialize = async () => {
-      const pendingExternalOpenFiles =
-        await window.electronAPI.consumePendingExternalOpenFiles();
+      try {
+        const pendingExternalOpenFiles =
+          await window.electronAPI.consumePendingExternalOpenFiles();
 
-      if (pendingExternalOpenFiles.length > 0) {
-        pendingExternalOpenFiles.forEach((payload) => {
-          enqueueExternalOpen(payload);
-        });
-      } else if (loaded.openLastFileOnStartup && loaded.lastOpenedFilePath) {
-        try {
-          const result = await window.electronAPI.readFile(
-            loaded.lastOpenedFilePath
-          );
-          if (result) {
-            replaceDocument(result.content, result.filePath);
+        if (pendingExternalOpenFiles.length > 0) {
+          for (const payload of pendingExternalOpenFiles) {
+            const result = await window.electronAPI.readFile(payload.filePath);
+            if (result) {
+              replaceDocument(result.content, result.filePath);
+            }
           }
-        } catch (error) {
-          console.error("Failed to open last file on startup:", error);
+        } else if (loaded.openLastFileOnStartup && loaded.lastOpenedFilePath) {
+          try {
+            const result = await window.electronAPI.readFile(
+              loaded.lastOpenedFilePath
+            );
+            if (result) {
+              replaceDocument(result.content, result.filePath);
+            }
+          } catch (error) {
+            console.error("Failed to open last file on startup:", error);
+          }
         }
+      } catch (error) {
+        console.error("Failed during app initialization:", error);
+      } finally {
+        setIsInitializing(false);
       }
-      setIsInitializing(false);
     };
 
     void initialize();
-  }, [enqueueExternalOpen, replaceDocument]);
+  }, [replaceDocument]);
 
   const handleOpen = useCallback(async () => {
     const proceed = await confirmDiscardIfNeeded("open");

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -9,7 +9,7 @@ import { createRoot } from "react-dom/client";
 import { CodeMirrorEditor } from "./components/CodeMirrorEditor";
 import { Chrome } from "./components/Chrome";
 import SettingsModal from "./components/SettingsModal";
-import { RenderMode } from "../shared/types";
+import { OpenSpecificFilePayload, RenderMode } from "../shared/types";
 import { markdownToHtml } from "./lib/export";
 import {
   defaultSettings,
@@ -57,6 +57,7 @@ const App = () => {
   const [isInitializing, setIsInitializing] = useState(true);
   const suppressDirtyRef = useRef(false);
   const editorViewRef = useRef<EditorView | null>(null);
+  const externalOpenSequenceRef = useRef(Promise.resolve());
   const commandRegistry = useMemo(() => createCommandRegistry(), []);
   const [systemPrefersDark, setSystemPrefersDark] = useState<boolean>(
     () => window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -92,33 +93,6 @@ const App = () => {
   useEffect(() => {
     window.electronAPI.notifyDirtyState(isDirty);
   }, [isDirty]);
-
-  useEffect(() => {
-    const loaded = loadSettings();
-    setSettings(loaded);
-
-    const initialize = async () => {
-      // Open last file on startup if enabled
-      if (loaded.openLastFileOnStartup && loaded.lastOpenedFilePath) {
-        try {
-          const result = await window.electronAPI.readFile(
-            loaded.lastOpenedFilePath
-          );
-          if (result) {
-            suppressDirtyRef.current = true;
-            setDoc(result.content);
-            setFilePath(result.filePath);
-            setIsDirty(false);
-          }
-        } catch (error) {
-          console.error("Failed to open last file on startup:", error);
-        }
-      }
-      setIsInitializing(false);
-    };
-
-    void initialize();
-  }, []);
 
   useEffect(() => {
     const media = window.matchMedia("(prefers-color-scheme: dark)");
@@ -191,6 +165,77 @@ const App = () => {
     [fileName, isDirty]
   );
 
+  const replaceDocument = useCallback(
+    (nextDoc: string, nextFilePath: string | null) => {
+      suppressDirtyRef.current = true;
+      setDoc(nextDoc);
+      setFilePath(nextFilePath);
+      setIsDirty(false);
+      focusEditor();
+    },
+    [focusEditor]
+  );
+
+  const handleExternalOpen = useCallback(
+    async ({ filePath: nextFilePath }: OpenSpecificFilePayload) => {
+      const proceed = await confirmDiscardIfNeeded("open");
+      if (!proceed) {
+        focusEditor();
+        return;
+      }
+
+      const result = await window.electronAPI.readFile(nextFilePath);
+      if (!result) {
+        focusEditor();
+        return;
+      }
+
+      replaceDocument(result.content, result.filePath);
+    },
+    [confirmDiscardIfNeeded, focusEditor, replaceDocument]
+  );
+
+  const enqueueExternalOpen = useCallback(
+    (payload: OpenSpecificFilePayload) => {
+      externalOpenSequenceRef.current = externalOpenSequenceRef.current.then(
+        async () => {
+          await handleExternalOpen(payload);
+        }
+      );
+    },
+    [handleExternalOpen]
+  );
+
+  useEffect(() => {
+    const loaded = loadSettings();
+    setSettings(loaded);
+
+    const initialize = async () => {
+      const pendingExternalOpenFiles =
+        await window.electronAPI.consumePendingExternalOpenFiles();
+
+      if (pendingExternalOpenFiles.length > 0) {
+        pendingExternalOpenFiles.forEach((payload) => {
+          enqueueExternalOpen(payload);
+        });
+      } else if (loaded.openLastFileOnStartup && loaded.lastOpenedFilePath) {
+        try {
+          const result = await window.electronAPI.readFile(
+            loaded.lastOpenedFilePath
+          );
+          if (result) {
+            replaceDocument(result.content, result.filePath);
+          }
+        } catch (error) {
+          console.error("Failed to open last file on startup:", error);
+        }
+      }
+      setIsInitializing(false);
+    };
+
+    void initialize();
+  }, [enqueueExternalOpen, replaceDocument]);
+
   const handleOpen = useCallback(async () => {
     const proceed = await confirmDiscardIfNeeded("open");
     if (!proceed) {
@@ -204,12 +249,8 @@ const App = () => {
       return;
     }
 
-    suppressDirtyRef.current = true;
-    setDoc(result.content);
-    setFilePath(result.filePath);
-    setIsDirty(false);
-    focusEditor();
-  }, [confirmDiscardIfNeeded, focusEditor]);
+    replaceDocument(result.content, result.filePath);
+  }, [confirmDiscardIfNeeded, focusEditor, replaceDocument]);
 
   const handleNew = useCallback(async () => {
     const proceed = await confirmDiscardIfNeeded("new");
@@ -324,6 +365,26 @@ const App = () => {
     handleSaveAs,
     setSettings,
   ]);
+
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.onExternalOpenFile((payload) => {
+      enqueueExternalOpen(payload);
+    });
+    window.electronAPI.notifyRendererReady();
+    return unsubscribe;
+  }, [enqueueExternalOpen]);
+
+  useEffect(() => {
+    const flushQueuedExternalOpens = async () => {
+      const pendingExternalOpenFiles =
+        await window.electronAPI.consumePendingExternalOpenFiles();
+      pendingExternalOpenFiles.forEach((payload) => {
+        enqueueExternalOpen(payload);
+      });
+    };
+
+    void flushQueuedExternalOpens();
+  }, [enqueueExternalOpen]);
 
   useEffect(() => {
     const unsubscribe = window.electronAPI.onFind(() => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -13,6 +13,10 @@ export interface OpenFileResult {
   content: string;
 }
 
+export interface OpenSpecificFilePayload {
+  filePath: string;
+}
+
 export interface SaveFilePayload {
   filePath?: string;
   content: string;
@@ -66,9 +70,15 @@ export interface IElectronAPI {
   onFind: (callback: () => void) => () => void;
   exportFile: (payload: ExportFilePayload) => Promise<boolean>;
   readFile: (filePath: string) => Promise<OpenFileResult | null>;
+  consumePendingExternalOpenFiles: () => Promise<OpenSpecificFilePayload[]>;
+  onExternalOpenFile: (
+    callback: (payload: OpenSpecificFilePayload) => void
+  ) => () => void;
+  notifyRendererReady: () => void;
   test?: {
     configure: (config: BedrockTestConfig) => Promise<BedrockTestState | null>;
     getState: () => Promise<BedrockTestState | null>;
     reset: () => Promise<BedrockTestState | null>;
+    simulateExternalOpen: (filePath: string) => Promise<boolean>;
   };
 }

--- a/tests/e2e/bedrock.e2e.spec.ts
+++ b/tests/e2e/bedrock.e2e.spec.ts
@@ -48,7 +48,11 @@ const findCompiledMainEntry = async (): Promise<string> => {
   return matches[0].file;
 };
 
-const launchBedrock = async (): Promise<{
+const launchBedrock = async (
+  options: {
+    initialExternalOpenPaths?: string[];
+  } = {}
+): Promise<{
   app: ElectronApplication;
   page: Page;
   userDataDir: string;
@@ -61,6 +65,9 @@ const launchBedrock = async (): Promise<{
     env: {
       ...process.env,
       BEDROCK_E2E: "1",
+      BEDROCK_E2E_INITIAL_EXTERNAL_OPEN_PATHS: JSON.stringify(
+        options.initialExternalOpenPaths ?? []
+      ),
       BEDROCK_USER_DATA_DIR: userDataDir,
       NODE_ENV: "test",
       SENTRY_DSN: "",
@@ -95,6 +102,12 @@ const getTestState = async (page: Page) => {
   return page.evaluate(async () => {
     return window.electronAPI.test?.getState() ?? null;
   });
+};
+
+const simulateExternalOpen = async (page: Page, filePath: string) => {
+  return page.evaluate(async (value) => {
+    return window.electronAPI.test?.simulateExternalOpen(value) ?? false;
+  }, filePath);
 };
 
 test.describe("Bedrock Electron pipeline", () => {
@@ -159,6 +172,37 @@ test.describe("Bedrock Electron pipeline", () => {
     } finally {
       await app.close().catch((): undefined => undefined);
       await fs.rm(outputDir, { recursive: true, force: true });
+      await fs.rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  test("queues startup external opens and reuses discard confirmation for running-app opens", async () => {
+    const { app, page, userDataDir } = await launchBedrock({
+      initialExternalOpenPaths: [fixturePath],
+    });
+
+    try {
+      await expect(page.locator("header")).toContainText("open-source.md");
+      await expect.poll(() => getEditorText(page)).toContain("Opened From Fixture");
+
+      await page.locator(".cm-content").click();
+      await page.keyboard.type("\nUnsaved change");
+
+      await configureTestHarness(page, { discardResponse: false });
+      await expect(await simulateExternalOpen(page, fixturePath)).toBe(true);
+
+      const cancelledState = await getTestState(page);
+      expect(cancelledState?.lastDiscardPrompt?.action).toBe("open");
+      await expect(page.locator("header")).toContainText("*open-source.md");
+      await expect.poll(() => getEditorText(page)).toContain("Unsaved change");
+
+      await configureTestHarness(page, { discardResponse: true });
+      await expect(await simulateExternalOpen(page, fixturePath)).toBe(true);
+
+      await expect(page.locator("header")).toContainText("open-source.md");
+      await expect.poll(() => getEditorText(page)).not.toContain("Unsaved change");
+    } finally {
+      await app.close().catch((): undefined => undefined);
       await fs.rm(userDataDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary
- register Bedrock as a macOS editor for `.md` files in the app bundle metadata
- handle macOS `open-file` events in the main process and queue external open requests until the renderer is ready
- route Finder-opened files through the existing single-window document replacement flow, including dirty-state discard confirmation
- extend the preload/shared IPC surface for external file-open delivery and test hooks
- add E2E coverage for startup-time external opens and dirty-document cancel/confirm behavior
- update `AGENTS.md` scratchpad with the feature change

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm test:e2e`