### PR TITLE
[codex] Add editor font preview

### DIFF
--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -64,10 +64,19 @@ const ABOUT_LINKS = {
 const editorFontOptions: Array<{
   value: EditorFontFamily;
   label: string;
+  css: string;
 }> = [
-  { value: "sans", label: "Sans" },
-  { value: "serif", label: "Serif" },
-  { value: "mono", label: "Mono" },
+  {
+    value: "sans",
+    label: "Sans",
+    css: '"Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  },
+  { value: "serif", label: "Serif", css: 'Georgia, "Times New Roman", serif' },
+  {
+    value: "mono",
+    label: "Mono",
+    css: '"Fira Code", "Source Code Pro", Monaco, Consolas, monospace',
+  },
 ];
 
 type SettingsModalProps = {
@@ -287,6 +296,9 @@ const SettingsModal = ({
 
   const activeCategoryLabel =
     categories.find((c) => c.id === activeCategory)?.label ?? "Settings";
+  const activeEditorFont =
+    editorFontOptions.find((option) => option.value === settings.editorFontFamily) ??
+    editorFontOptions[0];
 
   return (
     <div
@@ -393,6 +405,20 @@ const SettingsModal = ({
                         </Button>
                       </ItemActions>
                     </Item>
+                    <ItemSeparator />
+                    <div className="border-b border-border px-4 py-3">
+                      <div className="text-xs font-medium text-muted-foreground">
+                        Font preview
+                      </div>
+                      <div
+                        className="mt-2 rounded-md border border-border bg-card px-3 py-2 text-sm leading-6 text-card-foreground"
+                        style={{ fontFamily: activeEditorFont.css }}
+                      >
+                        # Heading
+                        <br />
+                        Plain text, `inline code`, and a [link](https://example.com)
+                      </div>
+                    </div>
                     <ItemSeparator />
                     <Item
                       size="sm"

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -64,19 +64,10 @@ const ABOUT_LINKS = {
 const editorFontOptions: Array<{
   value: EditorFontFamily;
   label: string;
-  css: string;
 }> = [
-  {
-    value: "sans",
-    label: "Sans",
-    css: '"Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-  },
-  { value: "serif", label: "Serif", css: 'Georgia, "Times New Roman", serif' },
-  {
-    value: "mono",
-    label: "Mono",
-    css: '"Fira Code", "Source Code Pro", Monaco, Consolas, monospace',
-  },
+  { value: "sans", label: "Sans" },
+  { value: "serif", label: "Serif" },
+  { value: "mono", label: "Mono" },
 ];
 
 type SettingsModalProps = {
@@ -296,10 +287,6 @@ const SettingsModal = ({
 
   const activeCategoryLabel =
     categories.find((c) => c.id === activeCategory)?.label ?? "Settings";
-  const activeEditorFont =
-    editorFontOptions.find((option) => option.value === settings.editorFontFamily) ??
-    editorFontOptions[0];
-
   return (
     <div
       className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60"
@@ -412,7 +399,7 @@ const SettingsModal = ({
                       </div>
                       <div
                         className="mt-2 rounded-md border border-border bg-card px-3 py-2 text-sm leading-6 text-card-foreground"
-                        style={{ fontFamily: activeEditorFont.css }}
+                        style={{ fontFamily: "var(--editor-font-family)" }}
                       >
                         # Heading
                         <br />

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -398,12 +398,22 @@ const SettingsModal = ({
                         Font preview
                       </div>
                       <div
-                        className="mt-2 rounded-md border border-border bg-card px-3 py-2 text-sm leading-6 text-card-foreground"
+                        className="mt-2 space-y-2 rounded-md border border-border bg-card px-3 py-2 text-card-foreground"
                         style={{ fontFamily: "var(--editor-font-family)" }}
                       >
-                        # Heading
-                        <br />
-                        Plain text, `inline code`, and a [link](https://example.com)
+                        <div className="text-lg font-semibold leading-snug">
+                          Heading
+                        </div>
+                        <p className="text-sm leading-6">
+                          Plain text,{" "}
+                          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.9em]">
+                            inline code
+                          </code>
+                          , and a{" "}
+                          <span className="text-primary underline underline-offset-4">
+                            link
+                          </span>
+                        </p>
                       </div>
                     </div>
                     <ItemSeparator />


### PR DESCRIPTION
## Summary

- Adds a live font preview to the Editor settings section.
- Uses the selected editor font family for preview text so users can compare sans, serif, and mono before closing Settings.

## Validation

- `pnpm lint`
- `pnpm typecheck`

Stacked on #86 / `codex/editor-quality-pass`.