### PR TITLE
[codex] Add selection-aware document stats

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -9,8 +9,13 @@ import { createRoot } from "react-dom/client";
 import { CodeMirrorEditor } from "./components/CodeMirrorEditor";
 import { Chrome } from "./components/Chrome";
 import SettingsModal from "./components/SettingsModal";
-import { OpenSpecificFilePayload, RenderMode } from "../shared/types";
+import {
+  OpenSpecificFilePayload,
+  RenderMode,
+  SelectionStats,
+} from "../shared/types";
 import { markdownToHtml } from "./lib/export";
+import { getDocumentStats } from "./lib/documentStats";
 import {
   defaultSettings,
   defaultKeyBindings,
@@ -55,20 +60,16 @@ const editorFontFamilyValues: Record<UserSettings["editorFontFamily"], string> =
     mono: '"Fira Code", "Source Code Pro", Monaco, Consolas, monospace',
   };
 
-const getDocumentStats = (value: string) => {
-  const trimmed = value.trim();
-  const words = trimmed ? trimmed.split(/\s+/).length : 0;
-  const chars = value.length;
-  const lines = value.length === 0 ? 1 : value.split(/\r\n|\r|\n/).length;
-  const readingMinutes = words === 0 ? 0 : Math.max(1, Math.ceil(words / 225));
-  return { words, chars, lines, readingMinutes };
-};
-
 const App = () => {
   const [doc, setDoc] = useState<string>("");
   const [filePath, setFilePath] = useState<string | null>(null);
   const [isDirty, setIsDirty] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [selectionStats, setSelectionStats] = useState<SelectionStats>({
+    hasSelection: false,
+    words: 0,
+    chars: 0,
+  });
   const [settings, setSettings] = useState<UserSettings>(defaultSettings);
   const [isInitializing, setIsInitializing] = useState(true);
   const suppressDirtyRef = useRef(false);
@@ -479,6 +480,7 @@ const App = () => {
         onExportPdf={() => void commands.run("file.exportPdf")}
         onOpenSettings={() => void commands.run("app.openSettings")}
         stats={documentStats}
+        selectionStats={selectionStats}
       >
         <CodeMirrorEditor
           value={doc}
@@ -491,6 +493,7 @@ const App = () => {
           keyBindings={keyBindings}
           placeholder="Start typing…"
           onChange={handleDocChange}
+          onSelectionStatsChange={setSelectionStats}
           onReady={(view) => {
             editorViewRef.current = view;
             view.focus();

--- a/src/renderer/components/Chrome.tsx
+++ b/src/renderer/components/Chrome.tsx
@@ -34,7 +34,7 @@ export type ChromeProps = {
     lines: number;
     readingMinutes: number;
   };
-  selectionStats?: SelectionStats;
+  selectionStats: SelectionStats;
   onNew: () => void;
   onOpen: () => void;
   onSave: () => void;

--- a/src/renderer/components/Chrome.tsx
+++ b/src/renderer/components/Chrome.tsx
@@ -24,6 +24,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
+import type { SelectionStats } from "../../shared/types";
 
 export type ChromeProps = {
   title: string;
@@ -33,6 +34,7 @@ export type ChromeProps = {
     lines: number;
     readingMinutes: number;
   };
+  selectionStats?: SelectionStats;
   onNew: () => void;
   onOpen: () => void;
   onSave: () => void;
@@ -47,6 +49,7 @@ export type ChromeProps = {
 export function Chrome({
   title,
   stats,
+  selectionStats,
   onNew,
   onOpen,
   onSave,
@@ -225,11 +228,18 @@ export function Chrome({
                   <div className="flex-1 min-h-0">{children}</div>
                 </div>
               </div>
-              <footer className="flex h-8 shrink-0 items-center justify-end gap-3 border-t border-border px-4 text-xs tabular-nums text-muted-foreground">
-                <span>{stats.lines} lines</span>
-                <span>{stats.words} words</span>
-                <span>{stats.chars} chars</span>
-                <span>{stats.readingMinutes} min read</span>
+              <footer className="flex h-8 shrink-0 items-center justify-between gap-3 border-t border-border px-4 text-xs tabular-nums text-muted-foreground">
+                <span className="min-w-0 truncate">
+                  {selectionStats?.hasSelection
+                    ? `selection: ${selectionStats.words} words / ${selectionStats.chars} chars`
+                    : "no selection"}
+                </span>
+                <div className="flex shrink-0 items-center gap-3">
+                  <span>{stats.lines} lines</span>
+                  <span>{stats.words} words</span>
+                  <span>{stats.chars} chars</span>
+                  <span>{stats.readingMinutes} min read</span>
+                </div>
               </footer>
             </div>
           </div>

--- a/src/renderer/components/CodeMirrorEditor.tsx
+++ b/src/renderer/components/CodeMirrorEditor.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useRef } from "react";
 import { EditorView } from "@codemirror/view";
-import { RenderMode, CursorPosition } from "../../shared/types";
+import {
+  RenderMode,
+  CursorPosition,
+  SelectionStats,
+} from "../../shared/types";
 import { ThemeName } from "../theme";
 import type { CommandRegistry, CommandRunner } from "../commands/commandSystem";
 import type { UserSettings } from "../settings";
@@ -27,6 +31,7 @@ type CodeMirrorEditorProps = {
   placeholder?: string;
   onChange: (nextValue: string) => void;
   onCursorChange?: (cursor: CursorPosition) => void;
+  onSelectionStatsChange?: (stats: SelectionStats) => void;
   onReady?: (view: EditorView) => void;
   className?: string;
 };
@@ -43,6 +48,7 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
   placeholder,
   onChange,
   onCursorChange,
+  onSelectionStatsChange,
   onReady,
   className,
 }) => {
@@ -63,6 +69,7 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
       placeholder,
       onDocChange: onChange,
       onCursorChange,
+      onSelectionStatsChange,
     });
 
     const state = createState(value, bundle);

--- a/src/renderer/editor/codemirror/extensions.ts
+++ b/src/renderer/editor/codemirror/extensions.ts
@@ -10,8 +10,13 @@ import { search, searchKeymap } from "@codemirror/search";
 import { markdown } from "@codemirror/lang-markdown";
 import { indentUnit } from "@codemirror/language";
 import { GFM } from "@lezer/markdown";
-import { CursorPosition, RenderMode } from "../../../shared/types";
+import {
+  CursorPosition,
+  RenderMode,
+  SelectionStats,
+} from "../../../shared/types";
 import { ThemeName } from "../../theme";
+import { getSelectionStats } from "../../lib/documentStats";
 import { buildThemeExtension } from "./theme";
 import { hybridMarkdown } from "./hybridMarkdown";
 import { linkClickHandler } from "./links";
@@ -25,6 +30,7 @@ type ExtensionOptions = {
   placeholder?: string;
   onDocChange: (doc: string) => void;
   onCursorChange?: (cursor: CursorPosition) => void;
+  onSelectionStatsChange?: (stats: SelectionStats) => void;
 };
 
 export type ExtensionBundle = {
@@ -68,6 +74,13 @@ export const createCmExtensions = (
         line: cursor.number - 1,
         char: update.state.selection.main.head - cursor.from,
       });
+    }
+    if (options.onSelectionStatsChange && update.selectionSet) {
+      const selectedText = update.state.selection.ranges
+        .filter((range) => !range.empty)
+        .map((range) => update.state.doc.sliceString(range.from, range.to))
+        .join("\n");
+      options.onSelectionStatsChange(getSelectionStats(selectedText));
     }
   });
 

--- a/src/renderer/editor/codemirror/extensions.ts
+++ b/src/renderer/editor/codemirror/extensions.ts
@@ -45,6 +45,18 @@ export type ExtensionBundle = {
 export const buildBaseKeymap =
   (): import("@codemirror/view").KeyBinding[] => [...searchKeymap];
 
+const selectionStatsEqual = (
+  left: SelectionStats,
+  right: SelectionStats | null
+): boolean => {
+  return (
+    right !== null &&
+    left.hasSelection === right.hasSelection &&
+    left.words === right.words &&
+    left.chars === right.chars
+  );
+};
+
 export const renderModeExtension = (mode: RenderMode): Extension => {
   if (mode === "hybrid") {
     return hybridMarkdown();
@@ -63,6 +75,7 @@ export const createCmExtensions = (
   const themeCompartment = new Compartment();
   const keymapCompartment = new Compartment();
   const renderModeCompartment = new Compartment();
+  let lastSelectionStats: SelectionStats | null = null;
 
   const updateListener = EditorView.updateListener.of((update) => {
     if (update.docChanged) {
@@ -75,12 +88,19 @@ export const createCmExtensions = (
         char: update.state.selection.main.head - cursor.from,
       });
     }
-    if (options.onSelectionStatsChange && update.selectionSet) {
+    if (
+      options.onSelectionStatsChange &&
+      (update.selectionSet || update.docChanged)
+    ) {
       const selectedText = update.state.selection.ranges
         .filter((range) => !range.empty)
         .map((range) => update.state.doc.sliceString(range.from, range.to))
         .join("\n");
-      options.onSelectionStatsChange(getSelectionStats(selectedText));
+      const selectionStats = getSelectionStats(selectedText);
+      if (!selectionStatsEqual(selectionStats, lastSelectionStats)) {
+        lastSelectionStats = selectionStats;
+        options.onSelectionStatsChange(selectionStats);
+      }
     }
   });
 

--- a/src/renderer/lib/documentStats.ts
+++ b/src/renderer/lib/documentStats.ts
@@ -1,0 +1,34 @@
+export type DocumentStats = {
+  words: number;
+  chars: number;
+  lines: number;
+  readingMinutes: number;
+};
+
+export type SelectionStats = {
+  hasSelection: boolean;
+  words: number;
+  chars: number;
+};
+
+const countWords = (value: string): number => {
+  const trimmed = value.trim();
+  return trimmed ? trimmed.split(/\s+/).length : 0;
+};
+
+export const getDocumentStats = (value: string): DocumentStats => {
+  const words = countWords(value);
+  const chars = value.length;
+  const lines = value.length === 0 ? 1 : value.split(/\r\n|\r|\n/).length;
+  const readingMinutes = words === 0 ? 0 : Math.max(1, Math.ceil(words / 225));
+  return { words, chars, lines, readingMinutes };
+};
+
+export const getSelectionStats = (selectedText: string): SelectionStats => {
+  const chars = selectedText.length;
+  return {
+    hasSelection: chars > 0,
+    words: countWords(selectedText),
+    chars,
+  };
+};

--- a/src/renderer/lib/documentStats.ts
+++ b/src/renderer/lib/documentStats.ts
@@ -1,14 +1,10 @@
+import type { SelectionStats } from "../../shared/types";
+
 export type DocumentStats = {
   words: number;
   chars: number;
   lines: number;
   readingMinutes: number;
-};
-
-export type SelectionStats = {
-  hasSelection: boolean;
-  words: number;
-  chars: number;
 };
 
 const countWords = (value: string): number => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,6 +3,12 @@ export interface CursorPosition {
   char: number;
 }
 
+export interface SelectionStats {
+  hasSelection: boolean;
+  words: number;
+  chars: number;
+}
+
 export type RenderMode = "hybrid" | "raw";
 
 // File Operation Types

--- a/tests/documentStats.test.ts
+++ b/tests/documentStats.test.ts
@@ -4,7 +4,18 @@ import {
   getSelectionStats,
 } from "../src/renderer/lib/documentStats";
 
-{
+const runTest = (name: string, fn: () => void) => {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    console.error(`✗ ${name}`);
+    console.error(error);
+    process.exitCode = 1;
+  }
+};
+
+runTest("document stats count lines words chars and reading time", () => {
   const stats = getDocumentStats("One two\nthree");
   assert.deepEqual(stats, {
     words: 3,
@@ -12,9 +23,9 @@ import {
     lines: 2,
     readingMinutes: 1,
   });
-}
+});
 
-{
+runTest("empty document stats still report one editable line", () => {
   const stats = getDocumentStats("");
   assert.deepEqual(stats, {
     words: 0,
@@ -22,22 +33,26 @@ import {
     lines: 1,
     readingMinutes: 0,
   });
-}
+});
 
-{
+runTest("selection stats count selected words and characters", () => {
   const stats = getSelectionStats(" selected text ");
   assert.deepEqual(stats, {
     hasSelection: true,
     words: 2,
     chars: 15,
   });
-}
+});
 
-{
+runTest("empty selection stats report no selection", () => {
   const stats = getSelectionStats("");
   assert.deepEqual(stats, {
     hasSelection: false,
     words: 0,
     chars: 0,
   });
+});
+
+if (process.exitCode && process.exitCode !== 0) {
+  throw new Error("One or more tests failed.");
 }

--- a/tests/documentStats.test.ts
+++ b/tests/documentStats.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import {
+  getDocumentStats,
+  getSelectionStats,
+} from "../src/renderer/lib/documentStats";
+
+{
+  const stats = getDocumentStats("One two\nthree");
+  assert.deepEqual(stats, {
+    words: 3,
+    chars: 13,
+    lines: 2,
+    readingMinutes: 1,
+  });
+}
+
+{
+  const stats = getDocumentStats("");
+  assert.deepEqual(stats, {
+    words: 0,
+    chars: 0,
+    lines: 1,
+    readingMinutes: 0,
+  });
+}
+
+{
+  const stats = getSelectionStats(" selected text ");
+  assert.deepEqual(stats, {
+    hasSelection: true,
+    words: 2,
+    chars: 15,
+  });
+}
+
+{
+  const stats = getSelectionStats("");
+  assert.deepEqual(stats, {
+    hasSelection: false,
+    words: 0,
+    chars: 0,
+  });
+}

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,2 +1,3 @@
 import "./controllerShortcuts.test";
+import "./documentStats.test";
 import "./themeSettings.test";


### PR DESCRIPTION
## Summary
- move document stats into a tested helper
- add selection-aware word and character counts from CodeMirror selections
- surface selection stats in the compact footer alongside document totals

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test:unit