### PR TITLE
[codex] Add task check toggle command

### DIFF
--- a/src/renderer/commands/commandSystem.ts
+++ b/src/renderer/commands/commandSystem.ts
@@ -6,6 +6,7 @@ import {
   createWrapSelectionOrWordCommand,
   insertHorizontalRuleCommand,
   toggleBlockquoteCommand,
+  toggleTaskCheckCommand,
   toggleFencedCodeBlockCommand,
   toggleOrderedListCommand,
   toggleTaskListCommand,
@@ -34,6 +35,7 @@ export type CommandId =
   | "insert.unorderedList"
   | "insert.orderedList"
   | "insert.taskList"
+  | "insert.toggleTaskCheck"
   | "insert.blockquote"
   | "insert.codeBlock"
   | "theme.set"
@@ -58,6 +60,7 @@ export type CommandArgs = {
   "insert.unorderedList": void;
   "insert.orderedList": void;
   "insert.taskList": void;
+  "insert.toggleTaskCheck": void;
   "insert.blockquote": void;
   "insert.codeBlock": void;
   "theme.set": { theme: ThemeName };
@@ -179,6 +182,7 @@ const editorCommands = {
   unorderedList: toggleUnorderedListCommand,
   orderedList: toggleOrderedListCommand,
   taskList: toggleTaskListCommand,
+  taskCheck: toggleTaskCheckCommand,
   blockquote: toggleBlockquoteCommand,
   codeBlock: toggleFencedCodeBlockCommand,
 } as const;
@@ -363,6 +367,17 @@ export const createCommandRegistry = (): CommandRegistry => {
       run: (ctx) => {
         const view = ctx.getEditorView();
         return view ? editorCommands.taskList(view) : false;
+      },
+    },
+    {
+      id: "insert.toggleTaskCheck",
+      title: "Toggle task check",
+      category: "Insert",
+      description: "Toggle checked state for task checklist items.",
+      requiresEditor: true,
+      run: (ctx) => {
+        const view = ctx.getEditorView();
+        return view ? editorCommands.taskCheck(view) : false;
       },
     },
     {

--- a/src/renderer/commands/commandSystem.ts
+++ b/src/renderer/commands/commandSystem.ts
@@ -35,7 +35,7 @@ export type CommandId =
   | "insert.unorderedList"
   | "insert.orderedList"
   | "insert.taskList"
-  | "insert.toggleTaskCheck"
+  | "insert.taskCheck"
   | "insert.blockquote"
   | "insert.codeBlock"
   | "theme.set"
@@ -60,7 +60,7 @@ export type CommandArgs = {
   "insert.unorderedList": void;
   "insert.orderedList": void;
   "insert.taskList": void;
-  "insert.toggleTaskCheck": void;
+  "insert.taskCheck": void;
   "insert.blockquote": void;
   "insert.codeBlock": void;
   "theme.set": { theme: ThemeName };
@@ -370,7 +370,7 @@ export const createCommandRegistry = (): CommandRegistry => {
       },
     },
     {
-      id: "insert.toggleTaskCheck",
+      id: "insert.taskCheck",
       title: "Toggle task check",
       category: "Insert",
       description: "Toggle checked state for task checklist items.",

--- a/src/renderer/components/EditorContextMenu.tsx
+++ b/src/renderer/components/EditorContextMenu.tsx
@@ -198,6 +198,12 @@ export function EditorContextMenu({
             </ContextMenuItem>
             <ContextMenuItem
               inset
+              onSelect={() => runCommand("insert.toggleTaskCheck")}
+            >
+              Toggle task check
+            </ContextMenuItem>
+            <ContextMenuItem
+              inset
               onSelect={() => runCommand("insert.blockquote")}
             >
               Quote

--- a/src/renderer/components/EditorContextMenu.tsx
+++ b/src/renderer/components/EditorContextMenu.tsx
@@ -198,7 +198,7 @@ export function EditorContextMenu({
             </ContextMenuItem>
             <ContextMenuItem
               inset
-              onSelect={() => runCommand("insert.toggleTaskCheck")}
+              onSelect={() => runCommand("insert.taskCheck")}
             >
               Toggle task check
             </ContextMenuItem>

--- a/src/renderer/editor/codemirror/commands.ts
+++ b/src/renderer/editor/codemirror/commands.ts
@@ -472,6 +472,43 @@ export const toggleTaskListCommand = (
     prefixForLine: () => "- [ ] ",
   });
 
+export const toggleTaskCheckCommand = (
+  view: import("@codemirror/view").EditorView
+): boolean => {
+  const { start, end } = getSelectedLineNumbers(view);
+  const taskLines = [];
+
+  for (let lineNumber = start; lineNumber <= end; lineNumber += 1) {
+    const line = view.state.doc.line(lineNumber);
+    const match = line.text.match(/^(\s*[-*+]\s+\[)([ xX])(\]\s+)/);
+    if (match) {
+      taskLines.push({ line, match });
+    }
+  }
+
+  if (taskLines.length === 0) {
+    return false;
+  }
+
+  const shouldUncheck = taskLines.every(({ match }) =>
+    /[xX]/.test(match[2])
+  );
+  const changes = taskLines.map(({ line, match }) => {
+    const markerOffset = match[1].length;
+    return {
+      from: line.from + markerOffset,
+      to: line.from + markerOffset + 1,
+      insert: shouldUncheck ? " " : "x",
+    };
+  });
+
+  view.dispatch({
+    changes,
+    scrollIntoView: true,
+  });
+  return true;
+};
+
 export const toggleBlockquoteCommand = (
   view: import("@codemirror/view").EditorView
 ): boolean =>

--- a/tests/controllerShortcuts.test.ts
+++ b/tests/controllerShortcuts.test.ts
@@ -4,6 +4,7 @@ import {
   toggleBlockquoteCommand,
   toggleFencedCodeBlockCommand,
   toggleOrderedListCommand,
+  toggleTaskCheckCommand,
   toggleTaskListCommand,
   toggleUnorderedListCommand,
 } from "../src/renderer/editor/codemirror/commands";
@@ -172,6 +173,33 @@ runTest("task list command toggles checklist markers", () => {
   view.state.selection.main = { from: 0, to: view.text.length };
   toggleTaskListCommand(view as unknown as EditorView);
   assert.equal(view.text, "one\ntwo");
+});
+
+runTest("task check command toggles unchecked tasks on", () => {
+  const view = new FakeView("- [ ] one\n- [x] two", { from: 0, to: 19 });
+
+  const handled = toggleTaskCheckCommand(view as unknown as EditorView);
+
+  assert.equal(handled, true);
+  assert.equal(view.text, "- [x] one\n- [x] two");
+});
+
+runTest("task check command toggles checked tasks off", () => {
+  const view = new FakeView("- [x] one\n- [X] two", { from: 0, to: 19 });
+
+  const handled = toggleTaskCheckCommand(view as unknown as EditorView);
+
+  assert.equal(handled, true);
+  assert.equal(view.text, "- [ ] one\n- [ ] two");
+});
+
+runTest("task check command falls through outside task lines", () => {
+  const view = new FakeView("- one", { from: 0, to: 5 });
+
+  const handled = toggleTaskCheckCommand(view as unknown as EditorView);
+
+  assert.equal(handled, false);
+  assert.equal(view.text, "- one");
 });
 
 runTest("blockquote command toggles selected lines", () => {


### PR DESCRIPTION
## Summary
- add an editor command to toggle Markdown task item checked state
- expose the task check toggle from the editor context menu
- cover checked, unchecked, and non-task fallthrough behavior with unit tests

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test:unit