### PR TITLE
[codex] Harden IPC payload validation

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,12 +14,16 @@ import {
   BedrockTestConfig,
   BedrockTestState,
   DiscardAction,
-  SaveFilePayload,
   OpenFileResult,
   OpenSpecificFilePayload,
   SaveFileResult,
-  ExportFilePayload,
 } from "../shared/types";
+import {
+  MAX_MARKDOWN_FILE_BYTES,
+  normalizeExportFilePayload,
+  normalizeSaveFilePayload,
+  safeExportBaseName,
+} from "./ipcValidation";
 import {
   buildRuntimeInfo,
   captureMainTelemetryException,
@@ -32,8 +36,6 @@ const MARKDOWN_DIALOG_FILTER = {
   name: "Markdown Files",
   extensions: ["md"],
 };
-const MAX_MARKDOWN_FILE_BYTES = 10 * 1024 * 1024;
-const MAX_EXPORT_HTML_BYTES = 25 * 1024 * 1024;
 
 const ensureMarkdownExtension = (filePath: string): string => {
   return filePath.toLowerCase().endsWith(".md") ? filePath : `${filePath}.md`;
@@ -131,16 +133,6 @@ const normalizeMarkdownFilePath = (filePath: unknown): string | null => {
   }
   const resolvedPath = path.resolve(filePath);
   return isMarkdownFilePath(resolvedPath) ? resolvedPath : null;
-};
-
-const assertReasonableContentSize = (
-  content: unknown,
-  maxBytes: number
-): content is string => {
-  return (
-    typeof content === "string" &&
-    Buffer.byteLength(content, "utf-8") <= maxBytes
-  );
 };
 
 const readMarkdownFile = async (
@@ -285,15 +277,16 @@ ipcMain.handle("file:consume-pending-external-open", () => {
 
 ipcMain.handle(
   "file:save",
-  async (event, args: SaveFilePayload): Promise<SaveFileResult | null> => {
+  async (event, args: unknown): Promise<SaveFileResult | null> => {
     try {
-      if (!assertReasonableContentSize(args.content, MAX_MARKDOWN_FILE_BYTES)) {
-        throw new Error("Markdown content is too large to save.");
+      const payload = normalizeSaveFilePayload(args);
+      if (!payload) {
+        throw new Error("Invalid save payload.");
       }
 
-      let targetPath = args.filePath
-        ? ensureMarkdownExtension(path.resolve(args.filePath))
-        : args.filePath;
+      let targetPath = payload.filePath
+        ? ensureMarkdownExtension(path.resolve(payload.filePath))
+        : payload.filePath;
 
       if (!targetPath) {
         const nextSavePath = resolveNextSavePath();
@@ -316,14 +309,13 @@ ipcMain.handle(
         }
       }
 
-      await fs.writeFile(targetPath, args.content, "utf-8");
+      await fs.writeFile(targetPath, payload.content, "utf-8");
       return { filePath: targetPath };
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "An unknown error occurred.";
       captureMainTelemetryException(error, {
         operation: "file:save",
-        filePath: args?.filePath,
       });
       dialog.showErrorBox("Unable to save file", message);
       return null;
@@ -402,15 +394,13 @@ ipcMain.handle("test:simulate-external-open", (_event, filePath: string) => {
 
 ipcMain.handle(
   "file:export",
-  async (event, args: ExportFilePayload): Promise<boolean> => {
+  async (event, args: unknown): Promise<boolean> => {
     try {
-      const { content, format, defaultFileName } = args;
-      if (format !== "html" && format !== "pdf") {
-        throw new Error("Unsupported export format.");
+      const payload = normalizeExportFilePayload(args);
+      if (!payload) {
+        throw new Error("Invalid export payload.");
       }
-      if (!assertReasonableContentSize(content, MAX_EXPORT_HTML_BYTES)) {
-        throw new Error("Export content is too large.");
-      }
+      const { content, format, defaultFileName } = payload;
 
       const extension = format === "html" ? "html" : "pdf";
       const filters =
@@ -418,7 +408,7 @@ ipcMain.handle(
           ? [{ name: "HTML Files", extensions: ["html"] }]
           : [{ name: "PDF Files", extensions: ["pdf"] }];
 
-      const baseName = defaultFileName || "Exported";
+      const baseName = safeExportBaseName(defaultFileName);
 
       const { canceled, filePath } = await dialog.showSaveDialog(
         BrowserWindow.fromWebContents(event.sender) ?? undefined,
@@ -507,7 +497,6 @@ ipcMain.handle(
         error instanceof Error ? error.message : "An unknown error occurred.";
       captureMainTelemetryException(error, {
         operation: "file:export",
-        format: args?.format,
       });
       dialog.showErrorBox("Unable to export file", message);
       return false;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,9 +20,9 @@ import {
 } from "../shared/types";
 import {
   MAX_MARKDOWN_FILE_BYTES,
-  normalizeExportFilePayload,
-  normalizeSaveFilePayload,
   safeExportBaseName,
+  validateExportFilePayload,
+  validateSaveFilePayload,
 } from "./ipcValidation";
 import {
   buildRuntimeInfo,
@@ -278,11 +278,14 @@ ipcMain.handle("file:consume-pending-external-open", () => {
 ipcMain.handle(
   "file:save",
   async (event, args: unknown): Promise<SaveFileResult | null> => {
+    let telemetryFilePath: string | undefined;
     try {
-      const payload = normalizeSaveFilePayload(args);
-      if (!payload) {
-        throw new Error("Invalid save payload.");
+      const validation = validateSaveFilePayload(args);
+      if (validation.ok === false) {
+        throw new Error(validation.message);
       }
+      const payload = validation.payload;
+      telemetryFilePath = payload.filePath;
 
       let targetPath = payload.filePath
         ? ensureMarkdownExtension(path.resolve(payload.filePath))
@@ -316,6 +319,7 @@ ipcMain.handle(
         error instanceof Error ? error.message : "An unknown error occurred.";
       captureMainTelemetryException(error, {
         operation: "file:save",
+        filePath: telemetryFilePath,
       });
       dialog.showErrorBox("Unable to save file", message);
       return null;
@@ -395,12 +399,15 @@ ipcMain.handle("test:simulate-external-open", (_event, filePath: string) => {
 ipcMain.handle(
   "file:export",
   async (event, args: unknown): Promise<boolean> => {
+    let telemetryFormat: string | undefined;
     try {
-      const payload = normalizeExportFilePayload(args);
-      if (!payload) {
-        throw new Error("Invalid export payload.");
+      const validation = validateExportFilePayload(args);
+      if (validation.ok === false) {
+        throw new Error(validation.message);
       }
+      const payload = validation.payload;
       const { content, format, defaultFileName } = payload;
+      telemetryFormat = format;
 
       const extension = format === "html" ? "html" : "pdf";
       const filters =
@@ -497,6 +504,7 @@ ipcMain.handle(
         error instanceof Error ? error.message : "An unknown error occurred.";
       captureMainTelemetryException(error, {
         operation: "file:export",
+        format: telemetryFormat,
       });
       dialog.showErrorBox("Unable to export file", message);
       return false;

--- a/src/main/ipcValidation.ts
+++ b/src/main/ipcValidation.ts
@@ -1,0 +1,91 @@
+import { ExportFilePayload, SaveFilePayload } from "../shared/types";
+
+export const MAX_MARKDOWN_FILE_BYTES = 10 * 1024 * 1024;
+export const MAX_EXPORT_HTML_BYTES = 25 * 1024 * 1024;
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null;
+};
+
+export const hasReasonableContentSize = (
+  content: unknown,
+  maxBytes: number
+): content is string => {
+  return (
+    typeof content === "string" &&
+    Buffer.byteLength(content, "utf-8") <= maxBytes
+  );
+};
+
+export const normalizeSaveFilePayload = (
+  payload: unknown
+): SaveFilePayload | null => {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  if (!hasReasonableContentSize(payload.content, MAX_MARKDOWN_FILE_BYTES)) {
+    return null;
+  }
+  if (
+    "filePath" in payload &&
+    payload.filePath !== undefined &&
+    (typeof payload.filePath !== "string" || payload.filePath.trim() === "")
+  ) {
+    return null;
+  }
+
+  const filePath =
+    typeof payload.filePath === "string" ? payload.filePath : undefined;
+
+  return {
+    content: payload.content,
+    filePath,
+  };
+};
+
+export const normalizeExportFilePayload = (
+  payload: unknown
+): ExportFilePayload | null => {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  if (payload.format !== "html" && payload.format !== "pdf") {
+    return null;
+  }
+  if (!hasReasonableContentSize(payload.content, MAX_EXPORT_HTML_BYTES)) {
+    return null;
+  }
+  if (
+    "defaultFileName" in payload &&
+    payload.defaultFileName !== undefined &&
+    typeof payload.defaultFileName !== "string"
+  ) {
+    return null;
+  }
+
+  const defaultFileName =
+    typeof payload.defaultFileName === "string"
+      ? payload.defaultFileName
+      : undefined;
+
+  return {
+    content: payload.content,
+    format: payload.format,
+    defaultFileName,
+  };
+};
+
+export const safeExportBaseName = (
+  defaultFileName: string | undefined
+): string => {
+  const rawName = defaultFileName || "Exported";
+  const lastSegment = rawName.split(/[\\/]/).pop() ?? "";
+  const withoutExtension = lastSegment.replace(/\.(?:html|pdf)$/i, "").trim();
+  const reservedCharacters = '<>:"|?*';
+  const sanitized = [...withoutExtension]
+    .map((char) =>
+      char.charCodeAt(0) < 32 || reservedCharacters.includes(char) ? "-" : char
+    )
+    .join("");
+  return sanitized || "Exported";
+};

--- a/src/main/ipcValidation.ts
+++ b/src/main/ipcValidation.ts
@@ -7,6 +7,14 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === "object" && value !== null;
 };
 
+const hasOwn = (value: Record<string, unknown>, key: string): boolean => {
+  return Object.prototype.hasOwnProperty.call(value, key);
+};
+
+type ValidationResult<T> =
+  | { ok: true; payload: T }
+  | { ok: false; message: string };
+
 export const hasReasonableContentSize = (
   content: unknown,
   maxBytes: number
@@ -20,58 +28,97 @@ export const hasReasonableContentSize = (
 export const normalizeSaveFilePayload = (
   payload: unknown
 ): SaveFilePayload | null => {
+  const result = validateSaveFilePayload(payload);
+  return result.ok ? result.payload : null;
+};
+
+export const validateSaveFilePayload = (
+  payload: unknown
+): ValidationResult<SaveFilePayload> => {
   if (!isRecord(payload)) {
-    return null;
+    return { ok: false, message: "Invalid save payload." };
   }
   if (!hasReasonableContentSize(payload.content, MAX_MARKDOWN_FILE_BYTES)) {
-    return null;
+    return {
+      ok: false,
+      message:
+        typeof payload.content === "string"
+          ? "Markdown content is too large to save."
+          : "Save content must be text.",
+    };
   }
+  const hasFilePath = hasOwn(payload, "filePath");
   if (
-    "filePath" in payload &&
+    hasFilePath &&
     payload.filePath !== undefined &&
     (typeof payload.filePath !== "string" || payload.filePath.trim() === "")
   ) {
-    return null;
+    return { ok: false, message: "Save file path must be a non-empty string." };
   }
 
   const filePath =
-    typeof payload.filePath === "string" ? payload.filePath : undefined;
+    hasFilePath && typeof payload.filePath === "string"
+      ? payload.filePath
+      : undefined;
 
   return {
-    content: payload.content,
-    filePath,
+    ok: true,
+    payload: {
+      content: payload.content,
+      filePath,
+    },
   };
 };
 
 export const normalizeExportFilePayload = (
   payload: unknown
 ): ExportFilePayload | null => {
+  const result = validateExportFilePayload(payload);
+  return result.ok ? result.payload : null;
+};
+
+export const validateExportFilePayload = (
+  payload: unknown
+): ValidationResult<ExportFilePayload> => {
   if (!isRecord(payload)) {
-    return null;
+    return { ok: false, message: "Invalid export payload." };
   }
   if (payload.format !== "html" && payload.format !== "pdf") {
-    return null;
+    return { ok: false, message: "Unsupported export format." };
   }
   if (!hasReasonableContentSize(payload.content, MAX_EXPORT_HTML_BYTES)) {
-    return null;
+    return {
+      ok: false,
+      message:
+        typeof payload.content === "string"
+          ? "Export content is too large."
+          : "Export content must be text.",
+    };
   }
+  const hasDefaultFileName = hasOwn(payload, "defaultFileName");
   if (
-    "defaultFileName" in payload &&
+    hasDefaultFileName &&
     payload.defaultFileName !== undefined &&
     typeof payload.defaultFileName !== "string"
   ) {
-    return null;
+    return {
+      ok: false,
+      message: "Export default filename must be a string.",
+    };
   }
 
   const defaultFileName =
-    typeof payload.defaultFileName === "string"
+    hasDefaultFileName && typeof payload.defaultFileName === "string"
       ? payload.defaultFileName
       : undefined;
 
   return {
-    content: payload.content,
-    format: payload.format,
-    defaultFileName,
+    ok: true,
+    payload: {
+      content: payload.content,
+      format: payload.format,
+      defaultFileName,
+    },
   };
 };
 
@@ -86,6 +133,14 @@ export const safeExportBaseName = (
     .map((char) =>
       char.charCodeAt(0) < 32 || reservedCharacters.includes(char) ? "-" : char
     )
-    .join("");
-  return sanitized || "Exported";
+    .join("")
+    .replace(/[ .]+$/g, "");
+
+  if (!sanitized) {
+    return "Exported";
+  }
+  if (/^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])$/i.test(sanitized)) {
+    return `${sanitized}-file`;
+  }
+  return sanitized;
 };

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,2 +1,3 @@
 import "./controllerShortcuts.test";
+import "./ipcValidation.test";
 import "./themeSettings.test";

--- a/tests/ipcValidation.test.ts
+++ b/tests/ipcValidation.test.ts
@@ -1,0 +1,55 @@
+import { strict as assert } from "assert";
+import {
+  MAX_MARKDOWN_FILE_BYTES,
+  normalizeExportFilePayload,
+  normalizeSaveFilePayload,
+  safeExportBaseName,
+} from "../src/main/ipcValidation";
+
+const runTest = (name: string, fn: () => void) => {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    console.error(`✗ ${name}`);
+    console.error(error);
+    process.exitCode = 1;
+  }
+};
+
+runTest("save payload validation rejects malformed file paths", () => {
+  assert.equal(normalizeSaveFilePayload({ content: "ok", filePath: "" }), null);
+  assert.equal(
+    normalizeSaveFilePayload({ content: "ok", filePath: 123 }),
+    null
+  );
+});
+
+runTest("save payload validation rejects oversized content", () => {
+  const oversized = "x".repeat(MAX_MARKDOWN_FILE_BYTES + 1);
+
+  assert.equal(normalizeSaveFilePayload({ content: oversized }), null);
+});
+
+runTest("save payload validation accepts valid content", () => {
+  assert.deepEqual(normalizeSaveFilePayload({ content: "ok" }), {
+    content: "ok",
+    filePath: undefined,
+  });
+});
+
+runTest("export payload validation rejects unsupported formats", () => {
+  assert.equal(
+    normalizeExportFilePayload({ content: "<p>ok</p>", format: "docx" }),
+    null
+  );
+});
+
+runTest("export default names are sanitized to a base filename", () => {
+  assert.equal(safeExportBaseName("../notes:bad?.html"), "notes-bad-");
+  assert.equal(safeExportBaseName(""), "Exported");
+});
+
+if (process.exitCode && process.exitCode !== 0) {
+  throw new Error("One or more tests failed.");
+}

--- a/tests/ipcValidation.test.ts
+++ b/tests/ipcValidation.test.ts
@@ -1,9 +1,12 @@
 import { strict as assert } from "assert";
 import {
+  MAX_EXPORT_HTML_BYTES,
   MAX_MARKDOWN_FILE_BYTES,
   normalizeExportFilePayload,
   normalizeSaveFilePayload,
   safeExportBaseName,
+  validateExportFilePayload,
+  validateSaveFilePayload,
 } from "../src/main/ipcValidation";
 
 const runTest = (name: string, fn: () => void) => {
@@ -31,6 +34,17 @@ runTest("save payload validation rejects oversized content", () => {
   assert.equal(normalizeSaveFilePayload({ content: oversized }), null);
 });
 
+runTest("save payload validation reports specific errors", () => {
+  assert.deepEqual(validateSaveFilePayload({ content: 12 }), {
+    ok: false,
+    message: "Save content must be text.",
+  });
+  assert.deepEqual(validateSaveFilePayload({ content: "ok", filePath: "" }), {
+    ok: false,
+    message: "Save file path must be a non-empty string.",
+  });
+});
+
 runTest("save payload validation accepts valid content", () => {
   assert.deepEqual(normalizeSaveFilePayload({ content: "ok" }), {
     content: "ok",
@@ -45,8 +59,49 @@ runTest("export payload validation rejects unsupported formats", () => {
   );
 });
 
+runTest("export payload validation rejects oversized content", () => {
+  const oversized = "x".repeat(MAX_EXPORT_HTML_BYTES + 1);
+
+  assert.equal(
+    normalizeExportFilePayload({ content: oversized, format: "html" }),
+    null
+  );
+  assert.deepEqual(
+    validateExportFilePayload({ content: oversized, format: "html" }),
+    { ok: false, message: "Export content is too large." }
+  );
+});
+
+runTest("export payload validation rejects non-string default names", () => {
+  assert.equal(
+    normalizeExportFilePayload({
+      content: "<p>ok</p>",
+      format: "html",
+      defaultFileName: 12,
+    }),
+    null
+  );
+});
+
+runTest("export payload validation accepts valid payloads", () => {
+  assert.deepEqual(
+    normalizeExportFilePayload({
+      content: "<p>ok</p>",
+      format: "pdf",
+      defaultFileName: "Notes",
+    }),
+    {
+      content: "<p>ok</p>",
+      format: "pdf",
+      defaultFileName: "Notes",
+    }
+  );
+});
+
 runTest("export default names are sanitized to a base filename", () => {
   assert.equal(safeExportBaseName("../notes:bad?.html"), "notes-bad-");
+  assert.equal(safeExportBaseName("CON.pdf"), "CON-file");
+  assert.equal(safeExportBaseName("notes. "), "notes");
   assert.equal(safeExportBaseName(""), "Exported");
 });
 


### PR DESCRIPTION
## Summary
- add pure validation for save/export IPC payloads before main-process handlers act on renderer input
- reject malformed save paths, unsupported export formats, and oversized content consistently
- sanitize export default filenames down to safe base names and cover validation behavior with unit tests

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test:unit
- pnpm test:e2e